### PR TITLE
SRE-62 Postgres 10 support

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -135,6 +135,7 @@ class postgresql::globals (
     '93'    => '2.1',
     '9.4'   => '2.1',
     '9.5'   => '2.2',
+    '10'    => '2.2',
     default => undef,
   }
   $globals_postgis_version = $postgis_version ? {


### PR DESCRIPTION
The postgis version is not used by Tradeshift, however the 2.2 version
might be a suitable candidate for 10, as postgis appear to be included
inside the main package.

@JesperTerkelsen @nokk 